### PR TITLE
Dedicated ETS table for group-pids mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ If you're using [rebar3](https://github.com/erlang/rebar3), add `syn` as a depen
 
 ```erlang
 {deps, [
-  {syn, {git, "git://github.com/ostinelli/syn.git", {tag, "2.1.1"}}}
+  {syn, {git, "git://github.com/ostinelli/syn.git", {tag, "2.1.2"}}}
 ]}.
 ```
 Or, if you're using [Hex.pm](https://hex.pm/) as package manager (with the [rebar3_hex](https://github.com/hexpm/rebar3_hex) plugin):
 
 ```erlang
 {deps, [
-  {syn, "2.1.1"}
+  {syn, "2.1.2"}
 ]}.
 ```
 

--- a/src/syn.app.src
+++ b/src/syn.app.src
@@ -1,7 +1,7 @@
 {application, syn,
     [
         {description, "A global Process Registry and Process Group manager."},
-        {vsn, "2.1.1"},
+        {vsn, "2.1.2"},
         {registered, [
             syn_backbone,
             syn_groups,

--- a/src/syn_backbone.erl
+++ b/src/syn_backbone.erl
@@ -113,6 +113,8 @@ init([]) ->
     ets:new(syn_groups_by_name, [ordered_set, public, named_table, {read_concurrency, true}, {write_concurrency, true}]),
     %% entries have format {{Pid, GroupName}, Meta, MonitorRef, Node}
     ets:new(syn_groups_by_pid, [ordered_set, public, named_table, {read_concurrency, true}, {write_concurrency, true}]),
+    %% entries have format {GroupName, Pid, Meta, Node}
+    ets:new(syn_groups_pids_by_group, [duplicate_bag, public, named_table, {read_concurrency, true}, {write_concurrency, true}]),
     %% init
     {ok, #state{}}.
 
@@ -166,6 +168,7 @@ terminate(Reason, _State) ->
     ets:delete(syn_registry_by_pid),
     ets:delete(syn_groups_by_name),
     ets:delete(syn_groups_by_pid),
+    ets:delete(syn_groups_pids_by_group),
     %% return
     terminated.
 

--- a/test/syn_groups_SUITE.erl
+++ b/test/syn_groups_SUITE.erl
@@ -1181,9 +1181,9 @@ three_nodes_anti_entropy(Config) ->
         {Pid1, SlaveNode1},
         {Pid2, SlaveNode2}
     ]),
-    Members = syn:get_members("my-group", with_meta),
-    Members = rpc:call(SlaveNode1, syn, get_members, ["my-group", with_meta]),
-    Members = rpc:call(SlaveNode2, syn, get_members, ["my-group", with_meta]),
+    Members = lists:sort(syn:get_members("my-group", with_meta)),
+    Members = lists:sort(rpc:call(SlaveNode1, syn, get_members, ["my-group", with_meta])),
+    Members = lists:sort(rpc:call(SlaveNode2, syn, get_members, ["my-group", with_meta])),
     [{Pid2Isolated, SlaveNode2}] = syn:get_members("my-group-isolated", with_meta),
     [{Pid2Isolated, SlaveNode2}] = rpc:call(SlaveNode1, syn, get_members, ["my-group-isolated", with_meta]),
     [{Pid2Isolated, SlaveNode2}] = rpc:call(SlaveNode2, syn, get_members, ["my-group-isolated", with_meta]).
@@ -1217,9 +1217,9 @@ three_nodes_anti_entropy_manual(Config) ->
         {Pid1, SlaveNode1},
         {Pid2, SlaveNode2}
     ]),
-    Members = syn:get_members("my-group", with_meta),
-    Members = rpc:call(SlaveNode1, syn, get_members, ["my-group", with_meta]),
-    Members = rpc:call(SlaveNode2, syn, get_members, ["my-group", with_meta]),
+    Members = lists:sort(syn:get_members("my-group", with_meta)),
+    Members = lists:sort(rpc:call(SlaveNode1, syn, get_members, ["my-group", with_meta])),
+    Members = lists:sort(rpc:call(SlaveNode2, syn, get_members, ["my-group", with_meta])),
     [{Pid2Isolated, SlaveNode2}] = syn:get_members("my-group-isolated", with_meta),
     [{Pid2Isolated, SlaveNode2}] = rpc:call(SlaveNode1, syn, get_members, ["my-group-isolated", with_meta]),
     [{Pid2Isolated, SlaveNode2}] = rpc:call(SlaveNode2, syn, get_members, ["my-group-isolated", with_meta]).


### PR DESCRIPTION
New ETS table has been added to map GroupName -> PIDs.
This improves retrieval time, especially in cases when theres big number
of registered groups and PIDs because there's no need to use ets:lookup/2
anymore. The only drowbacks are:
- the memory footprint required to store another ETS table,
- result of syn:get_members/1 and syn:get_members/2 are not sorted anymore